### PR TITLE
Exposes response context in case of Vonage internal api error

### DIFF
--- a/lib/vonage/number_insight.rb
+++ b/lib/vonage/number_insight.rb
@@ -25,7 +25,7 @@ module Vonage
     def basic(params)
       response = request('/ni/basic/json', params: params)
 
-      raise Error, response[:status_message] unless response.status.zero?
+      raise ServiceError.new(response[:status_message], response: response) unless response.status.zero?
 
       response
     end
@@ -57,7 +57,7 @@ module Vonage
     def standard(params)
       response = request('/ni/standard/json', params: params)
 
-      raise Error, response[:status_message] unless response.status.zero?
+      raise ServiceError.new(response[:status_message], response: response) unless response.status.zero?
 
       response
     end
@@ -93,7 +93,7 @@ module Vonage
     def advanced(params)
       response = request('/ni/advanced/json', params: params)
 
-      raise Error, response[:status_message] unless response.status.zero?
+      raise ServiceError.new(response[:status_message], response: response) unless response.status.zero?
 
       response
     end
@@ -132,7 +132,7 @@ module Vonage
     def advanced_async(params)
       response = request('/ni/advanced/async/json', params: params)
 
-      raise Error, response[:status_message] unless response.status.zero?
+      raise ServiceError.new(response[:status_message], response: response) unless response.status.zero?
 
       response
     end

--- a/lib/vonage/service_error.rb
+++ b/lib/vonage/service_error.rb
@@ -1,0 +1,16 @@
+# typed: strong
+
+module Vonage
+  class ServiceError < Error
+    extend T::Sig
+
+    sig { returns(Vonage::Response) }
+    attr_reader :response
+
+    sig { params(message: T.nilable(String), response: Vonage::Response).void }
+    def initialize(message, response:)
+      @response = response
+      super(message)
+    end
+  end
+end

--- a/lib/vonage/sms.rb
+++ b/lib/vonage/sms.rb
@@ -105,7 +105,7 @@ module Vonage
       response = request('/sms/json', params: hyphenate(params), type: Post)
 
       unless response.messages.first.status == '0'
-        raise Error, response.messages.first[:error_text]
+        raise ServiceError.new(response.messages.first[:error_text], response: response)
       end
 
       response

--- a/lib/vonage/verify.rb
+++ b/lib/vonage/verify.rb
@@ -64,7 +64,7 @@ module Vonage
     def request(params, uri = '/verify/json')
       response = http_request(uri, params: params, type: Post)
 
-      raise Error, response[:error_text] if error?(response)
+      raise ServiceError.new(response[:error_text], response: response) if error?(response)
 
       response
     end
@@ -97,7 +97,7 @@ module Vonage
     def check(params)
       response = http_request('/verify/check/json', params: params, type: Post)
 
-      raise Error, response[:error_text] if error?(response)
+      raise ServiceError.new(response[:error_text], response: response) if error?(response)
 
       response
     end
@@ -124,7 +124,7 @@ module Vonage
     def search(params)
       response = http_request('/verify/search/json', params: params)
 
-      raise Error, response[:error_text] if error?(response)
+      raise ServiceError.new(response[:error_text], response: response) if error?(response)
 
       response
     end
@@ -151,7 +151,7 @@ module Vonage
     def control(params)
       response = http_request('/verify/control/json', params: params, type: Post)
 
-      raise Error, response[:error_text] if error?(response)
+      raise ServiceError.new(response[:error_text], response: response) if error?(response)
 
       response
     end
@@ -238,7 +238,7 @@ module Vonage
     def psd2(params, uri = '/verify/psd2/json')
       response = http_request(uri, params: params, type: Post)
 
-      raise Error, response[:error_text] if error?(response)
+      raise ServiceError.new(response[:error_text], response: response) if error?(response)
 
       response
     end

--- a/test/vonage/number_insight_test.rb
+++ b/test/vonage/number_insight_test.rb
@@ -35,9 +35,12 @@ class Vonage::NumberInsightTest < Vonage::Test
 
     assert_kind_of Vonage::Response, number_insight.basic(params)
 
-    assert_raises Vonage::Error do
+    error = assert_raises Vonage::ServiceError do
       number_insight.basic(params)
     end
+
+    assert_kind_of Vonage::Error, error
+    assert_kind_of Vonage::Response, error.response
   end
 
   def test_standard_method
@@ -47,9 +50,12 @@ class Vonage::NumberInsightTest < Vonage::Test
 
     assert_kind_of Vonage::Response, number_insight.standard(params)
 
-    assert_raises Vonage::Error do
+    error = assert_raises Vonage::ServiceError do
       number_insight.standard(params)
     end
+
+    assert_kind_of Vonage::Error, error
+    assert_kind_of Vonage::Response, error.response
   end
 
   def test_advanced_method
@@ -59,9 +65,12 @@ class Vonage::NumberInsightTest < Vonage::Test
 
     assert_kind_of Vonage::Response, number_insight.advanced(params)
 
-    assert_raises Vonage::Error do
+    error = assert_raises Vonage::ServiceError do
       number_insight.advanced(params)
     end
+
+    assert_kind_of Vonage::Error, error
+    assert_kind_of Vonage::Response, error.response
   end
 
   def test_advanced_async_method
@@ -71,8 +80,11 @@ class Vonage::NumberInsightTest < Vonage::Test
 
     assert_kind_of Vonage::Response, number_insight.advanced_async(params)
 
-    assert_raises Vonage::Error do
+    error = assert_raises Vonage::ServiceError do
       number_insight.advanced_async(params)
     end
+
+    assert_kind_of Vonage::Error, error
+    assert_kind_of Vonage::Response, error.response
   end
 end

--- a/test/vonage/sms_test.rb
+++ b/test/vonage/sms_test.rb
@@ -31,9 +31,12 @@ class Vonage::SMSTest < Vonage::Test
 
     assert_kind_of Vonage::Response, sms.send(params)
 
-    assert_raises Vonage::Error do
+    error = assert_raises Vonage::ServiceError do
       sms.send(params)
     end
+
+    assert_kind_of Vonage::Error, error
+    assert_kind_of Vonage::Response, error.response
   end
 
   def test_mapping_underscored_keys_to_hyphenated_string_keys

--- a/test/vonage/verify_test.rb
+++ b/test/vonage/verify_test.rb
@@ -33,9 +33,12 @@ class Vonage::VerifyTest < Vonage::Test
 
     assert_kind_of Vonage::Response, verify.request(params)
 
-    assert_raises Vonage::Error do
+    error = assert_raises Vonage::ServiceError do
       verify.request(params)
     end
+
+    assert_kind_of Vonage::Error, error
+    assert_kind_of Vonage::Response, error.response
   end
 
   def test_check_method
@@ -47,9 +50,12 @@ class Vonage::VerifyTest < Vonage::Test
 
     assert_kind_of Vonage::Response, verify.check(params)
 
-    assert_raises Vonage::Error do
+    error = assert_raises Vonage::ServiceError do
       verify.check(params)
     end
+
+    assert_kind_of Vonage::Error, error
+    assert_kind_of Vonage::Response, error.response
   end
 
   def test_search_method
@@ -61,9 +67,12 @@ class Vonage::VerifyTest < Vonage::Test
 
     assert_kind_of Vonage::Response, verify.search(params)
 
-    assert_raises Vonage::Error do
+    error = assert_raises Vonage::ServiceError do
       verify.search(params)
     end
+
+    assert_kind_of Vonage::Error, error
+    assert_kind_of Vonage::Response, error.response
   end
 
   def test_control_method
@@ -75,9 +84,12 @@ class Vonage::VerifyTest < Vonage::Test
 
     assert_kind_of Vonage::Response, verify.control(params)
 
-    assert_raises Vonage::Error do
+    error = assert_raises Vonage::ServiceError do
       verify.control(params)
     end
+
+    assert_kind_of Vonage::Error, error
+    assert_kind_of Vonage::Response, error.response
   end
 
   def test_cancel_method
@@ -89,9 +101,12 @@ class Vonage::VerifyTest < Vonage::Test
 
     assert_kind_of Vonage::Response, verify.cancel(request_id)
 
-    assert_raises Vonage::Error do
+    error = assert_raises Vonage::ServiceError do
       verify.cancel(request_id)
     end
+
+    assert_kind_of Vonage::Error, error
+    assert_kind_of Vonage::Response, error.response
   end
 
   def test_trigger_next_event_method
@@ -103,9 +118,12 @@ class Vonage::VerifyTest < Vonage::Test
 
     assert_kind_of Vonage::Response, verify.trigger_next_event(request_id)
 
-    assert_raises Vonage::Error do
+    error = assert_raises Vonage::ServiceError do
       verify.trigger_next_event(request_id)
     end
+
+    assert_kind_of Vonage::Error, error
+    assert_kind_of Vonage::Response, error.response
   end
 
   def test_psd2_method
@@ -117,8 +135,11 @@ class Vonage::VerifyTest < Vonage::Test
 
     assert_kind_of Vonage::Response, verify.psd2(params)
 
-    assert_raises Vonage::Error do
+    error = assert_raises Vonage::ServiceError do
       verify.psd2(params)
     end
+
+    assert_kind_of Vonage::Error, error
+    assert_kind_of Vonage::Response, error.response
   end
 end


### PR DESCRIPTION
## Context

Since the `7.0.0` release, we're not able anymore to properly handle Vonage response errors.

For example, before the `7.0.0` release, with the `number_insight` API , we were able to handle response errors like

```ruby
response = client.number_insight.standard(params)

case response.status
when '0'
  handle_success(response)
when '44'
  handle_lookup_handler_error(response)
else
  handle_error(response)
end
```

Since the `7.0.0`, in case of this kind of errors (`response.status != '0'`), it raises a generic `Vonage::Error` without exposing any response context, which means we're not able anymore to properly handle API responses

## Implementation choice

- Added a specific `Vonage::ServiceError` which exposes the `Vonage::Response` as `response` attribute
- Raise this specifc `Vonage::ServiceError` instead of the generic `Vonage::Error` when relevant (`number_insight`, `sms` and `verify` APIs)

We're now able to handle API response errors like

```ruby
begin
  response = client.number_insight.standard(params)
  handle_success(response)
rescue Vonage::ServerError # (5xx HTTP status)
  # Do something
rescue Vonage::ClientError # (4xx HTTP status, or validation before sending request failed)
  # Do something else
rescue Vonage::ServiceError => e # (2xx HTTP status, but http_response.body.status != '0')
  case e.response.status
  when '44'
    handle_lookup_handler_error(e.response)
  else
    handle_error(e.response)
  end
rescue Vonage::Error
  # World is broken
end
```

This won't change anything to the current behavior, only adds the ability to rescue the specific `Vonage::ServiceError` which will give more response context

## Links

- Vonage issue [#197](https://github.com/Vonage/vonage-ruby-sdk/issues/197)